### PR TITLE
Removed redundant null check

### DIFF
--- a/src/main/java/joshie/harvest/core/HFClientProxy.java
+++ b/src/main/java/joshie/harvest/core/HFClientProxy.java
@@ -16,12 +16,10 @@ public class HFClientProxy extends HFCommonProxy {
 
     public void setBlockModelResourceLocation(Item item, String name) {
         name = name.replace(".", "_");
-        if (item != null) {
-            if (item instanceof ItemBlockHF) {
-                ((ItemBlockHF)item).getBlock().registerModels(item, name);
-            } else {
-                ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(new ResourceLocation(HFModInfo.MODID, name), "inventory"));
-            }
+        if(item instanceof ItemBlockHF){
+            ((ItemBlockHF) item).getBlock().registerModels(item, name);
+        } else if(item != null){
+            ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(new ResourceLocation(HFModInfo.MODID, name), "inventory"));
         }
     }
 }


### PR DESCRIPTION
In Java "instanceof" provides a null check inherently, only necessary to check if its not an instance of ItemBlockHF